### PR TITLE
A poor fix for stem rotation skin bug

### DIFF
--- a/Choc_Chicago_Steno_Thumb.scad
+++ b/Choc_Chicago_Steno_Thumb.scad
@@ -367,7 +367,7 @@ module keycap(keyID = 0, cutLen = 0, visualizeDish = false, crossSection = false
             translate([Stab/2,0,0])rotate([0,0,StemRot])cherry_stem(KeyHeight(keyID), slop);
             translate([-Stab/2,0,0])rotate([0,0,StemRot])cherry_stem(KeyHeight(keyID), slop);
           }
-          translate([0,0,-.001])skin([for (i=[0:stemLayers-1]) transform(translation(StemTranslation(i,keyID)), rounded_rectangle_profile(StemTransform(i, keyID),fn=fn,r=1 /*StemRadius(i, keyID) */ ))]); //outer shell
+          translate([0,0,-.001])rotate([0,0,StemRot])skin([for (i=[0:stemLayers-1]) transform(translation(StemTranslation(i,keyID)), rounded_rectangle_profile(StemTransform(i, keyID),fn=fn,r=1 /*StemRadius(i, keyID) */ ))]); //outer shell
        }
         
      }


### PR DESCRIPTION
When stemrot is set to 90, the layers immediately above the stems are not rotated. This small change rotates those layers created by the function, but the stems don't sit within the rounded rectangular base. They are connected and should print fine, but are not as intended 

See issue #3 for more/other words.