### PR TITLE
Allow for corner radius on stem length and width

### DIFF
--- a/Choc_Chicago_Steno_Thumb.scad
+++ b/Choc_Chicago_Steno_Thumb.scad
@@ -462,15 +462,16 @@ module cherry_stem(depth, slop) {
 module choc_stem(draftAng = 5) {
   stemHeight = 3.1;
   dia = .15;
-  wids = 1.2/2;
+  rad = dia/2;
+  wids = 1.1/2;
   lens = 2.9/2; 
   module Stem() {
     difference(){
       translate([0,0,-stemHeight/2])linear_extrude(height = stemHeight)hull(){
-        translate([wids-dia,-3/2])circle(d=dia);
-        translate([-wids+dia,-3/2])circle(d=dia);
-        translate([wids-dia, 3/2])circle(d=dia);
-        translate([-wids+dia, 3/2])circle(d=dia);
+        translate([wids-rad,-lens+rad])circle(d=dia);
+        translate([-wids+rad,-lens+rad])circle(d=dia);
+        translate([wids-rad, lens-rad])circle(d=dia);
+        translate([-wids+rad, lens-rad])circle(d=dia);
       }
 
     //cuts


### PR DESCRIPTION
Without this change the length (y dimension) of the stem is `3+dia/2` which is greater than the choc stem recess of `3mm`. See http://www.kailh.com/en/Products/Ks/CS/319.html for reference.

This also tidies the total width to not be reliant on the corner diameter either. (True width was `wids*2 + dia`)